### PR TITLE
fixes parsing of datetime members

### DIFF
--- a/Directory.Build.Props
+++ b/Directory.Build.Props
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.33" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.103" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ pr:
   - rel/*
 
 pool:
-  vmImage: vs2017-win2016
+  vmImage: windows-2019
 
 variables: 
   BuildConfiguration: Release

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,9 @@ pool:
 variables: 
   BuildConfiguration: Release
 
+env:
+  MSBUILDSINGLELOADCONTEXT: 1
+  
 steps:
 - task: DotNetCoreCLI@2  
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,13 +13,6 @@ variables:
   BuildConfiguration: Release
   
 steps:
-- task: UseDotNet@2
-  displayName: 'Use .NET 6 sdk'
-  inputs:
-    packageType: sdk
-    version: 6.0.101
-    installationPath: $(Agent.ToolsDirectory)/dotnet
-    
 - task: DotNetCoreCLI@2  
   inputs:
     command: custom

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,9 +11,6 @@ pool:
 
 variables: 
   BuildConfiguration: Release
-
-env:
-  MSBUILDSINGLELOADCONTEXT: 1
   
 steps:
 - task: DotNetCoreCLI@2  

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ pr:
   - rel/*
 
 pool:
-  vmImage: windows-2019
+  vmImage: windows-2022
 
 variables: 
   BuildConfiguration: Release

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,13 @@ variables:
   BuildConfiguration: Release
   
 steps:
+- task: UseDotNet@2
+  displayName: 'Use .NET 6 sdk'
+  inputs:
+    packageType: sdk
+    version: 6.0.101
+    installationPath: $(Agent.ToolsDirectory)/dotnet
+    
 - task: DotNetCoreCLI@2  
   inputs:
     command: custom

--- a/mcs/class/System.Runtime.Serialization.Formatters.Soap/System.Runtime.Serialization.Formatters.Soap/SoapReader.cs
+++ b/mcs/class/System.Runtime.Serialization.Formatters.Soap/System.Runtime.Serialization.Formatters.Soap/SoapReader.cs
@@ -687,8 +687,15 @@ namespace System.Runtime.Serialization.Formatters.Soap {
 				return objMgr.GetObject(componentHref);
 			}
 
-			if(componentType == null)
+			if (componentType == null)
+			{
 				return xmlReader.ReadElementString();
+			}
+			else if (mapper.IsInternalSoapType(componentType))
+			{
+				object obj = mapper.ReadInternalSoapValue(this, componentType);
+				return obj;
+			}
 
 			componentId = NextAvailableId;
 			objReturn = DeserializeObject(

--- a/mcs/class/System.Runtime.Serialization.Formatters.Soap/System.Runtime.Serialization.Formatters.Soap/System.Runtime.Serialization.Formatters.Soap.csproj
+++ b/mcs/class/System.Runtime.Serialization.Formatters.Soap/System.Runtime.Serialization.Formatters.Soap/System.Runtime.Serialization.Formatters.Soap.csproj
@@ -15,9 +15,4 @@
     <Compile Include="..\..\..\build\common\MonoTODOAttribute.cs" />
   </ItemGroup>
   
-  <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.5.103" />
-  </ItemGroup>
-
 </Project>

--- a/mcs/class/System.Runtime.Serialization.Formatters.Soap/System.Runtime.Serialization.Formatters.Soap/System.Runtime.Serialization.Formatters.Soap.csproj
+++ b/mcs/class/System.Runtime.Serialization.Formatters.Soap/System.Runtime.Serialization.Formatters.Soap/System.Runtime.Serialization.Formatters.Soap.csproj
@@ -14,5 +14,10 @@
   <ItemGroup>
     <Compile Include="..\..\..\build\common\MonoTODOAttribute.cs" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.5.103" />
+  </ItemGroup>
 
 </Project>

--- a/mcs/class/System.Runtime.Serialization.Formatters.Soap/Test/InternalSoapValuesTest.cs
+++ b/mcs/class/System.Runtime.Serialization.Formatters.Soap/Test/InternalSoapValuesTest.cs
@@ -31,11 +31,14 @@ namespace SoapShared
 			var r = new System.IO.StreamReader(ms);
 			string s = r.ReadToEnd();
 			TestContext.WriteLine(s);
+			DateTime expectedTime = DateTime.Parse("2022-05-07T10:40:46.0618350-04:00");
+
+			//test needs to expect the date to be formatted in the datetime of the local system
 			string expected =
-@"<SOAP-ENV:Envelope xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:SOAP-ENC=""http://schemas.xmlsoap.org/soap/encoding/"" xmlns:SOAP-ENV=""http://schemas.xmlsoap.org/soap/envelope/"" xmlns:clr=""http://schemas.microsoft.com/clr/"" SOAP-ENV:encodingStyle=""http://schemas.xmlsoap.org/soap/encoding/"">
+$@"<SOAP-ENV:Envelope xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:SOAP-ENC=""http://schemas.xmlsoap.org/soap/encoding/"" xmlns:SOAP-ENV=""http://schemas.xmlsoap.org/soap/envelope/"" xmlns:clr=""http://schemas.microsoft.com/clr/"" SOAP-ENV:encodingStyle=""http://schemas.xmlsoap.org/soap/encoding/"">
   <SOAP-ENV:Body>
     <a1:SerializableClass id=""ref-1"" xmlns:a1=""http://schemas.microsoft.com/clr/nsassem/SoapShared/Test%2C%20Version%3D1.0.0.0%2C%20Culture%3Dneutral%2C%20PublicKeyToken%3D64d05efcff27afd3"">
-      <m_time xsi:type=""xsd:dateTime"">2022-05-07T10:40:46.0618350-04:00</m_time>
+      <m_time xsi:type=""xsd:dateTime"">{expectedTime.ToLocalTime():yyyy-MM-ddTHH:mm:ss.fffffffzzz}</m_time>
     </a1:SerializableClass>
   </SOAP-ENV:Body>
 </SOAP-ENV:Envelope>";

--- a/mcs/class/System.Runtime.Serialization.Formatters.Soap/Test/InternalSoapValuesTest.cs
+++ b/mcs/class/System.Runtime.Serialization.Formatters.Soap/Test/InternalSoapValuesTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using NUnit.Framework;
 using System.Runtime.Serialization.Formatters.Soap;
+using System.Runtime.Serialization;
 
 namespace SoapShared
 {
@@ -20,12 +21,92 @@ namespace SoapShared
 			ms = new MemoryStream();
 			sf = new SoapFormatter();
 		}
+		[Test]
+		public void WriteDateTimeData()
+		{
+			object obj = new SerializableClass();
+			ms = new MemoryStream();
+			Serialize(obj, ms);
+			ms.Position = 0;
+			var r = new System.IO.StreamReader(ms);
+			string s = r.ReadToEnd();
+			TestContext.WriteLine(s);
+			string expected =
+@"<SOAP-ENV:Envelope xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:SOAP-ENC=""http://schemas.xmlsoap.org/soap/encoding/"" xmlns:SOAP-ENV=""http://schemas.xmlsoap.org/soap/envelope/"" xmlns:clr=""http://schemas.microsoft.com/clr/"" SOAP-ENV:encodingStyle=""http://schemas.xmlsoap.org/soap/encoding/"">
+  <SOAP-ENV:Body>
+    <a1:SerializableClass id=""ref-1"" xmlns:a1=""http://schemas.microsoft.com/clr/nsassem/SoapShared/Test%2C%20Version%3D1.0.0.0%2C%20Culture%3Dneutral%2C%20PublicKeyToken%3D64d05efcff27afd3"">
+      <m_time xsi:type=""xsd:dateTime"">2022-05-07T10:40:46.0618350-04:00</m_time>
+    </a1:SerializableClass>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>";
+			Assert.AreEqual(expected, s);
+		}
+
+		[Test]
+		public void ReadDateTimeData()
+		{
+			string soapMessage =
+@"<SOAP-ENV:Envelope xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:SOAP-ENC=""http://schemas.xmlsoap.org/soap/encoding/"" xmlns:SOAP-ENV=""http://schemas.xmlsoap.org/soap/envelope/"" xmlns:clr=""http://schemas.microsoft.com/clr/"" SOAP-ENV:encodingStyle=""http://schemas.xmlsoap.org/soap/encoding/"">
+  <SOAP-ENV:Body>
+    <a1:SerializableClass id=""ref-1"" xmlns:a1=""http://schemas.microsoft.com/clr/nsassem/SoapShared/Test%2C%20Version%3D1.0.0.0%2C%20Culture%3Dneutral%2C%20PublicKeyToken%3D64d05efcff27afd3"">
+      <m_time xsi:type=""xsd:dateTime"">2022-05-07T10:40:46.0618350-04:00</m_time>
+    </a1:SerializableClass>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>";
+
+			ms = new MemoryStream(System.Text.UTF8Encoding.Default.GetBytes(soapMessage));
+			ms.Position = 0;
+			var obj = Deserialize(ms) as SerializableClass;
+			
+			DateTime expectedTime = DateTime.Parse("2022-05-07T10:40:46.0618350-04:00");
+			Assert.AreEqual(expectedTime, obj.Time);
+		}
+
+		[Test]
+		public void WriteTimeSpanData()
+		{
+			object obj = new Serializable2Class();
+			ms = new MemoryStream();
+			Serialize(obj, ms);
+			ms.Position = 0;
+			var r = new System.IO.StreamReader(ms);
+			string s = r.ReadToEnd(); 
+			TestContext.WriteLine(s);
+			string expected =
+@"<SOAP-ENV:Envelope xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:SOAP-ENC=""http://schemas.xmlsoap.org/soap/encoding/"" xmlns:SOAP-ENV=""http://schemas.xmlsoap.org/soap/envelope/"" xmlns:clr=""http://schemas.microsoft.com/clr/"" SOAP-ENV:encodingStyle=""http://schemas.xmlsoap.org/soap/encoding/"">
+  <SOAP-ENV:Body>
+    <a1:Serializable2Class id=""ref-1"" xmlns:a1=""http://schemas.microsoft.com/clr/nsassem/SoapShared/Test%2C%20Version%3D1.0.0.0%2C%20Culture%3Dneutral%2C%20PublicKeyToken%3D64d05efcff27afd3"">
+      <m_time xsi:type=""xsd:duration"">P1DT</m_time>
+    </a1:Serializable2Class>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>";
+			Assert.AreEqual(expected, s);
+		}
+
+		[Test]
+		public void ReadTimeSpanData()
+		{
+			string soapMessage =
+@"<SOAP-ENV:Envelope xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:SOAP-ENC=""http://schemas.xmlsoap.org/soap/encoding/"" xmlns:SOAP-ENV=""http://schemas.xmlsoap.org/soap/envelope/"" xmlns:clr=""http://schemas.microsoft.com/clr/"" SOAP-ENV:encodingStyle=""http://schemas.xmlsoap.org/soap/encoding/"">
+  <SOAP-ENV:Body>
+    <a1:Serializable2Class id=""ref-1"" xmlns:a1=""http://schemas.microsoft.com/clr/nsassem/SoapShared/Test%2C%20Version%3D1.0.0.0%2C%20Culture%3Dneutral%2C%20PublicKeyToken%3D64d05efcff27afd3"">
+      <m_time xsi:type=""xsd:duration"">P1DT</m_time>
+    </a1:Serializable2Class>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>";
+
+			ms = new MemoryStream(System.Text.UTF8Encoding.Default.GetBytes(soapMessage));
+			ms.Position = 0;
+			var obj = Deserialize(ms) as Serializable2Class;
+
+			Assert.AreEqual(new TimeSpan(TimeSpan.TicksPerDay), obj.Time);
+		}
 
 		[Test]
 		public void WriteReadData()
 		{
 			SerializedClass c = new SerializedClass();
-			
+
 			SerializeDeserialize(c);
 			SerializeDeserialize(new SerializedClass[]{c,c});
 			SerializeDeserialize(c.str);
@@ -40,8 +121,8 @@ namespace SoapShared
 			SerializeDeserialize(c.m_object);
 			SerializeDeserialize(c.m_sbyte);
 			SerializeDeserialize(c.m_short);
-			//SerializeDeserialize(c.m_time);
 			SerializeDeserialize(c.m_timeSpan);
+			SerializeDeserialize(c.m_time);
 			SerializeDeserialize(c.m_uint);
 			SerializeDeserialize(c.m_ulong);
 			SerializeDeserialize(c.m_ushort);
@@ -87,6 +168,41 @@ namespace SoapShared
 		public object m_object = new object();
 		public TimeSpan m_timeSpan = TimeSpan.FromTicks(TimeSpan.TicksPerDay);
 		public byte[] m_bytes = new byte[10];
-		//public DateTime m_time = DateTime.Now;
+		public DateTime m_time = DateTime.Now;
+	}
+
+	[Serializable]
+	class SerializableClass : ISerializable
+	{
+		private DateTime m_time = DateTime.Parse("2022-05-07T10:40:46.0618350-04:00");
+		public DateTime Time => m_time;
+
+		public SerializableClass() { }
+		public SerializableClass(SerializationInfo info, StreamingContext context)
+		{
+			m_time = info.GetDateTime(nameof(m_time));
+		}
+
+		public void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			info.AddValue(nameof(m_time), m_time);
+		}
+	}
+	[Serializable]
+	class Serializable2Class : ISerializable
+	{
+		private TimeSpan m_time = new TimeSpan(TimeSpan.TicksPerDay);
+		public TimeSpan Time => m_time;
+
+		public Serializable2Class() { }
+		public Serializable2Class(SerializationInfo info, StreamingContext context)
+		{
+			m_time = (TimeSpan)info.GetValue(nameof(m_time), typeof(TimeSpan));
+		}
+
+		public void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			info.AddValue(nameof(m_time), m_time);
+		}
 	}
 }

--- a/mcs/class/System.Runtime.Serialization.Formatters.Soap/Test/Test.csproj
+++ b/mcs/class/System.Runtime.Serialization.Formatters.Soap/Test/Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/mcs/class/System.Runtime.Serialization.Formatters.Soap/Test/Test.csproj
+++ b/mcs/class/System.Runtime.Serialization.Formatters.Soap/Test/Test.csproj
@@ -10,13 +10,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="nunit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\System.Runtime.Serialization.Formatters.Soap\System.Runtime.Serialization.Formatters.Soap.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.5.103" />
   </ItemGroup>
 
 </Project>

--- a/mcs/class/System.Runtime.Serialization.Formatters.Soap/Test/Test.csproj
+++ b/mcs/class/System.Runtime.Serialization.Formatters.Soap/Test/Test.csproj
@@ -19,9 +19,4 @@
     <ProjectReference Include="..\System.Runtime.Serialization.Formatters.Soap\System.Runtime.Serialization.Formatters.Soap.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.5.103" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Fixes #4 

When reading components, if the type is represented as an internal SOAP type then read it as-is instead of treating it as a complex object.

Added tests to prove the serialization and deserialization of objects with DateTime, and TimeSpan members.
