### PR TITLE
Fixes tests to be version agnostic

### DIFF
--- a/mcs/class/System.Runtime.Serialization.Formatters.Soap/Test/InternalSoapValuesTest.cs
+++ b/mcs/class/System.Runtime.Serialization.Formatters.Soap/Test/InternalSoapValuesTest.cs
@@ -78,7 +78,7 @@ namespace SoapShared
 			string soapMessage =
 @"<SOAP-ENV:Envelope xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:SOAP-ENC=""http://schemas.xmlsoap.org/soap/encoding/"" xmlns:SOAP-ENV=""http://schemas.xmlsoap.org/soap/envelope/"" xmlns:clr=""http://schemas.microsoft.com/clr/"" SOAP-ENV:encodingStyle=""http://schemas.xmlsoap.org/soap/encoding/"">
   <SOAP-ENV:Body>
-    <a1:Serializable2Class id=""ref-1"" xmlns:a1=""http://schemas.microsoft.com/clr/nsassem/SoapShared/Test%2C%20Version%3D1.0.0.0%2C%20Culture%3Dneutral%2C%20PublicKeyToken%3D64d05efcff27afd3"">
+    <a1:Serializable2Class id=""ref-1"" xmlns:a1=""http://schemas.microsoft.com/clr/nsassem/SoapShared/Test"">
       <m_time xsi:type=""xsd:duration"">P1DT</m_time>
     </a1:Serializable2Class>
   </SOAP-ENV:Body>

--- a/mcs/class/System.Runtime.Serialization.Formatters.Soap/Test/InternalSoapValuesTest.cs
+++ b/mcs/class/System.Runtime.Serialization.Formatters.Soap/Test/InternalSoapValuesTest.cs
@@ -34,15 +34,8 @@ namespace SoapShared
 			DateTime expectedTime = DateTime.Parse("2022-05-07T10:40:46.0618350-04:00");
 
 			//test needs to expect the date to be formatted in the datetime of the local system
-			string expected =
-$@"<SOAP-ENV:Envelope xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:SOAP-ENC=""http://schemas.xmlsoap.org/soap/encoding/"" xmlns:SOAP-ENV=""http://schemas.xmlsoap.org/soap/envelope/"" xmlns:clr=""http://schemas.microsoft.com/clr/"" SOAP-ENV:encodingStyle=""http://schemas.xmlsoap.org/soap/encoding/"">
-  <SOAP-ENV:Body>
-    <a1:SerializableClass id=""ref-1"" xmlns:a1=""http://schemas.microsoft.com/clr/nsassem/SoapShared/Test%2C%20Version%3D1.0.0.0%2C%20Culture%3Dneutral%2C%20PublicKeyToken%3D64d05efcff27afd3"">
-      <m_time xsi:type=""xsd:dateTime"">{expectedTime.ToLocalTime():yyyy-MM-ddTHH:mm:ss.fffffffzzz}</m_time>
-    </a1:SerializableClass>
-  </SOAP-ENV:Body>
-</SOAP-ENV:Envelope>";
-			Assert.AreEqual(expected, s);
+			string expected = @$"<m_time xsi:type=""xsd:dateTime"">{expectedTime.ToLocalTime():yyyy-MM-ddTHH:mm:ss.fffffffzzz}</m_time>";
+			Assert.IsTrue(s.Contains(expected), "Expected the serialized soap string to contain the correctly formatted datetime string");
 		}
 
 		[Test]
@@ -51,7 +44,7 @@ $@"<SOAP-ENV:Envelope xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xm
 			string soapMessage =
 @"<SOAP-ENV:Envelope xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:SOAP-ENC=""http://schemas.xmlsoap.org/soap/encoding/"" xmlns:SOAP-ENV=""http://schemas.xmlsoap.org/soap/envelope/"" xmlns:clr=""http://schemas.microsoft.com/clr/"" SOAP-ENV:encodingStyle=""http://schemas.xmlsoap.org/soap/encoding/"">
   <SOAP-ENV:Body>
-    <a1:SerializableClass id=""ref-1"" xmlns:a1=""http://schemas.microsoft.com/clr/nsassem/SoapShared/Test%2C%20Version%3D1.0.0.0%2C%20Culture%3Dneutral%2C%20PublicKeyToken%3D64d05efcff27afd3"">
+    <a1:SerializableClass id=""ref-1"" xmlns:a1=""http://schemas.microsoft.com/clr/nsassem/SoapShared/Test"">
       <m_time xsi:type=""xsd:dateTime"">2022-05-07T10:40:46.0618350-04:00</m_time>
     </a1:SerializableClass>
   </SOAP-ENV:Body>
@@ -75,15 +68,8 @@ $@"<SOAP-ENV:Envelope xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xm
 			var r = new System.IO.StreamReader(ms);
 			string s = r.ReadToEnd(); 
 			TestContext.WriteLine(s);
-			string expected =
-@"<SOAP-ENV:Envelope xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:SOAP-ENC=""http://schemas.xmlsoap.org/soap/encoding/"" xmlns:SOAP-ENV=""http://schemas.xmlsoap.org/soap/envelope/"" xmlns:clr=""http://schemas.microsoft.com/clr/"" SOAP-ENV:encodingStyle=""http://schemas.xmlsoap.org/soap/encoding/"">
-  <SOAP-ENV:Body>
-    <a1:Serializable2Class id=""ref-1"" xmlns:a1=""http://schemas.microsoft.com/clr/nsassem/SoapShared/Test%2C%20Version%3D1.0.0.0%2C%20Culture%3Dneutral%2C%20PublicKeyToken%3D64d05efcff27afd3"">
-      <m_time xsi:type=""xsd:duration"">P1DT</m_time>
-    </a1:Serializable2Class>
-  </SOAP-ENV:Body>
-</SOAP-ENV:Envelope>";
-			Assert.AreEqual(expected, s);
+			string expected = @"<m_time xsi:type=""xsd:duration"">P1DT</m_time>";
+			Assert.IsTrue(s.Contains(expected), "Expected the serialized soap string to contain the correctly formatted timespan string");
 		}
 
 		[Test]


### PR DESCRIPTION
Following up on #5, this modifies the tests to remove any version numbers in soap strings, and reduces checking soap strings to simply looking for the fields we're interested in.